### PR TITLE
change array key for IM/OM

### DIFF
--- a/src/ValueObjects/TransformationV2.php
+++ b/src/ValueObjects/TransformationV2.php
@@ -39,13 +39,13 @@ class TransformationV2
 
     public function addInputMappingTable(array $inputMappingTable): void
     {
-        $this->inputMappingTables[$inputMappingTable['source']] =
+        $this->inputMappingTables[$inputMappingTable['destination']] =
             $this->renameInputMappingKeys($inputMappingTable);
     }
 
     public function addOutputMappingTable(array $outputMappingTable): void
     {
-        $this->outputMappingTables[$outputMappingTable['destination']] =
+        $this->outputMappingTables[$outputMappingTable['source']] =
             $this->renameOutputMappingKeys($outputMappingTable);
     }
 


### PR DESCRIPTION
Náhodou jsem na to narazil při testování: https://keboola.slack.com/archives/C09U3R1J4/p1623942433074800

jde o to že u IM bude vždy destination a u OM bude zase source

obráceně to být nemusí